### PR TITLE
Update index.md

### DIFF
--- a/docs/about/index.md
+++ b/docs/about/index.md
@@ -10,7 +10,7 @@ comprised of ~215 team members and 27 institutions. The program is funded primar
 National Institutes of Health (NIH) Other Transaction Awards (OTA) mechanism and an NIH contract awarded 
 to support development of a Translator user interface (UI).
 
-An overview of the Translator timeline, in the context of key milestones and award funding, is depicted below.
+An overview of the Translator timeline, in the context of key milestones and award funding from program inception through September 2022, is depicted below.
 
 ![image](https://user-images.githubusercontent.com/26254388/174347625-c20cc7b1-134b-4a19-ab21-72c4ad4d2f89.png)
 
@@ -18,11 +18,11 @@ Taken from Fecho _et al._ 2022, Supplementary Figure 1
 
 Translator is currently being used to promote serendipitous discovery and augment human reasoning in a variety of
 disease spaces, including Fanconi anemia, systemic sclerosis, cystic fibrosis, Parkinson’s disease,
-and drug-induced liver injury.
+drug-induced liver injury, and many others.
 
 ## Key Technical Achievements
 
-- **Common Semantics**: Biolink Model (Unni _et al._ 2022) has been adopted as a standard upper-level ontology to support semantic harmonization across disparate ontologies and data/knowledge sources
+- **Common Semantics**: Biolink Model (Unni _et al._ 2022) has been adopted as a standard data model and upper-level ontology to support semantic harmonization across disparate ontologies and data/knowledge sources
 - **Entity Resolution**: SRI Name Resolution and Node Normalization services provide entity resolution to harmonize across disparate vocabularies and identifier systems
 - **Common Queries**: TRAPI has been adopted as an API standard to support query across Translator components
 - **Discoverability**: SmartAPI Registry provides a platform for discovering Translator tools and components, including metadata to explain what functionalities those components or services support
@@ -38,8 +38,8 @@ and drug-induced liver injury.
 ## References
 
 1. Austin CP, Colvis, CM, Southall NT. **Deconstructing the Translational Tower of Babel.** _Clin Transl Sci_, 2019;12(2):85. [doi:10.1111/cts.12595](https://ascpt.onlinelibrary.wiley.com/doi/10.1111/cts.12595). [PMID:30412342](https://pubmed.ncbi.nlm.nih.gov/30412342/).
-2. The Biomedical Data Translator Consortium (BDTC). **Toward a Universal Biomedical Data Translator.** _Clin Transl Sci_, 2019a;12(2):91–94. [doi:10.1111/cts.12592](https://ascpt.onlinelibrary.wiley.com/doi/full/10.1111/cts.12592). [PMID:30412337](https://pubmed.ncbi.nlm.nih.gov/30412337/).
-3. BDTC. **The Biomedical Data Translator program: conception, culture, and community.** _Clin Transl Sci_, 2019b;12(2):86–90. doi: 10.1111/cts.13021. [PMID:30412340](https://pubmed.ncbi.nlm.nih.gov/30412340/).
+2. The Biomedical Data Translator Consortium. **Toward a Universal Biomedical Data Translator.** _Clin Transl Sci_, 2019a;12(2):91–94. [doi:10.1111/cts.12592](https://ascpt.onlinelibrary.wiley.com/doi/full/10.1111/cts.12592). [PMID:30412337](https://pubmed.ncbi.nlm.nih.gov/30412337/).
+3. The Biomedical Data Translator Consortium. **The Biomedical Data Translator program: conception, culture, and community.** _Clin Transl Sci_, 2019b;12(2):86–90. doi: 10.1111/cts.13021. [PMID:30412340](https://pubmed.ncbi.nlm.nih.gov/30412340/).
 4. Fecho K, Thessen AE, Baranzini SE, et al. and The Biomedical Data Translator Consortium. **Progress toward a Universal Biomedical Data Translator.** _Clin Transl Sci_, 2022 May 25. [doi:10.1111/cts.13301](https://ascpt.onlinelibrary.wiley.com/doi/full/10.1111/cts.13301). [PMID:35611543](https://pubmed.ncbi.nlm.nih.gov/35611543/).
 5. Unni DR, Moxon SAT, Bada M, et al. and the Biomedical Data Translator Consortium. **Biolink Model: a universal schema for knowledge graphs in clinical, biomedical, and translational science.** _Clin Transl Sci_, 2022 June 6. [doi:10.1111/cts.13302](https://ascpt.onlinelibrary.wiley.com/doi/full/10.1111/cts.13302).
 

--- a/docs/architecture/ara.md
+++ b/docs/architecture/ara.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-TBA  - description of what an ARA is and what it does (Chris B)
+Translator "Autonomous Relay Agents" (ARAs) build build upon the knowledge contributed by KPs by way of reasoning and inference and in response to user-defined queries. ARAs also apply scoring-and-ranking algorithms to query results in order to assist with user interpretation and evaluation of answers.
 
 ## Tutorials
 

--- a/docs/architecture/ars.md
+++ b/docs/architecture/ars.md
@@ -2,7 +2,7 @@
 
 _**Revision required! Initial copy lifted from https://github.com/NCATSTranslator/Translator-All/wiki**_ (Mark Williams)
 
-The Autonomous Relay System (ARS) by the Link Brokers team for NCATS Biomedical Data Translator
+The Autonomous Relay System (ARS) was developed by the Link Brokers team for NCATS Biomedical Data Translator
 
 The ARS is built by NCATS staff and relays translator queries from the user to the autonomous relay agents (ARAs) using an iterative process to generate results in the form of a knowledge graph that is then provided to the user.
 

--- a/docs/architecture/biolink/core_knowledge_graph_principles.md
+++ b/docs/architecture/biolink/core_knowledge_graph_principles.md
@@ -20,7 +20,7 @@ and accelerate translational science.
 For more about Translator and how it uses KGs, please see the [2022 Translator paper](https://ascpt.onlinelibrary.wiley.com/doi/10.1111/cts.13301) (reference 2 below).
 
 ## What is Biolink Model?
-[Biolink Model](https://github.com/biolink/biolink-model) is an open source data model that can be used to formalize
+[Biolink Model](https://github.com/biolink/biolink-model) is an open-source data model that can be used to formalize
 the relationships between data structures in translational science.
 It incorporates object-oriented classification and graph-oriented features.
 The core of the model is a set of hierarchical, interconnected classes (or categories) and relationships between them (or predicates),
@@ -30,10 +30,10 @@ The model provides class and edge attributes and associations that guide how ent
 For more info about Biolink Model, please see the [Biolink Model paper](https://onlinelibrary.wiley.com/doi/10.1111/cts.13302) and [Biolink documentation](https://biolink.github.io/biolink-model/) (references 3 and 4 below).
 
 ## What role does Biolink Model play in Translator?
-The Translator Consortium uses Biolink Model as an upper-level graph-oriented universal schema that supports semantic harmonization and reasoning
+The Translator Consortium has adopted Biolink Model as an upper-level graph-oriented universal schema that supports semantic harmonization and reasoning
 across diverse Translator knowledge sources.
-In order to interoperate between knowledge sources and reason across KGs, Biolink Model was adopted by Translator as the common dialect
-to provide rich annotation metadata to the nodes and edges in disparate graphs, thus enabling queries over the entire Translator KG ecosystem,
+Biolink Model was adopted by Translator as the common dialect
+to provide rich annotation metadata to the nodes and edges in disparate graphs, thus enabling queries across the entire Translator KG ecosystem,
 despite incompatibilities in the underlying data sources.
 The result is a federated, harmonized ecosystem that supports advanced reasoning and inference to derive biomedical insights based on user queries.
 

--- a/docs/architecture/epc.md
+++ b/docs/architecture/epc.md
@@ -1,12 +1,12 @@
 # Evidence, Provenance and Confidence Metadata
 
-The EPC Modeling team is working to standardize different subdomains of EPC metadata one at a time, based on priority of use cases and requirements.
+The Evidence, Provenance and Confidence (EPC) team is working to model and standardize different subdomains of EPC metadata one at a time, based on priority of use cases and requirements.
 
-1. **Retrieval Source Provenance:** How to report information resources from which the knowledge expressed in an Edge was retrieved, directly or indirectly. See [Documentation](https://docs.google.com/document/d/177sOmjTueIK4XKJ0GjxsARg909CaU71tReIehAp5DDo/edit#).
-2. **Supporting Publications/Documents:**  How to describe publications or other documents that support the knowledge expressed in an edge (by directly reporting this knowlege, or providing evidence used to support it)
-3. **'At-a-Glance' Knowledge Provenance:** a small set of edge properties that provide a high-level EPC summary, allowing users to make a first pass assessment of confidence and relevance for a given Edge.
-4. **Statement Provenance:** How to describe the provenance of the knowledge as expressed in an Edge - including who authored the statement, when they did so, and what reasoning methods/guidelines they used in doing so. 
-5. **Evidence and Supporting Data:** How to repor information interpreted as evidence in generating the knowledge expressed in an Edge, and describe its provenance (e.g. detials of experiments or analyses performed to generate the evidence).
-6. **Statement Confidence:** how to report on the level of confidence an agent has in the truth of the knowledge expressedin an Edge. 
+1. **Retrieval Source Provenance:** How to report information resources from which the knowledge expressed in an edge was retrieved, whether directly or indirectly. See [Documentation](https://docs.google.com/document/d/177sOmjTueIK4XKJ0GjxsARg909CaU71tReIehAp5DDo/edit#).
+2. **Supporting Publications/Documents:**  How to describe publications or other documents that support the knowledge expressed in an edge, by directly reporting the knowlege, or providing the evidence used to support it
+3. **'At-a-Glance' Knowledge Provenance:** a small set of edge properties that provides a high-level EPC summary, allowing users to make a first-pass assessment of confidence and relevance for a given Edge.
+4. **Statement Provenance:** How to describe the provenance of the knowledge as expressed in an edge, including who authored the statement, when they did so, and what reasoning methods/guidelines they used in doing so. 
+5. **Evidence and Supporting Data:** How to report information interpreted as evidence in generating the knowledge expressed in an edge, and describe its provenance, e.g., details of experimental design or analyses performed to generate the evidence.
+6. **Statement Confidence:** How to report on the level of confidence an agent has in the truth of the knowledge expressed in an edge. 
 
 Model Documentation and Implementation Guidance for each subdomain are provided for now as links to external resources, which will be unified/centralized here in future efforts. To date, only the first subdomain has been fully standardized, as described in documents linked above.

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -2,19 +2,19 @@
 
 # Translator Architecture
 
-In brief, the Translator system is comprised of five main components, shown in the diagram below 
+The Translator system is comprised of five main components, shown in the diagram below 
 ([Fecho et al. 2022](../about/index.md#references)). Knowledge Providers (KPs) contribute domain-specific, high-value
 information abstracted from one or more underlying ‘knowledge sources’. Autonomous Relay Agents (ARAs) build upon the 
 knowledge contributed by KPs by way of reasoning and inference across KPs. The Autonomous Relay System (ARS) functions
-as a central relay station, is managed by NCATS, and is intended to broadcast user queries to the broader Translator
-ecosystem. A UI is under development but intended to serve as a public user interface to the Translator system.
+as a central relay station and broadcasts user queries to the broader Translator
+ecosystem and, in turn, compiles results. A user interface (UI) is under development and intended to serve as a public UI to the Translator system.
 Finally, a Standards and Reference Implementation (SRI) Component provides services and community-based collaboration
 guidance related to the development, adoption, and implementation of the standards needed to achieve the overall
 implementation goals of the Translator system.
 
 ![image](https://user-images.githubusercontent.com/26254388/174347804-0412fbd2-f61f-4573-8073-2408c3c41e15.png)
 
-**Figure 1**  ([Fecho _et al._ 2022](../about/index.md#references)).
+**Figure 1**  High-level overview of the Translator architecture ([Fecho _et al._ 2022](../about/index.md#references)).
 
 * https://github.com/NCATSTranslator/TranslatorArchitecture
 
@@ -28,15 +28,15 @@ Shown below is the translation of that user question into a TRAPI query.
 
 ![image](https://user-images.githubusercontent.com/26254388/174348079-4bf2ff96-db8e-432e-ba5d-7c82475ec821.png)
 
-**Figure 2** ([Fecho _et al._ 2022](../about/index.md#references))
+**Figure 2** Step-by-step translation of a user question into a TRAPI query ([Fecho _et al._ 2022](../about/index.md#references))
 
 In response to the query, Translator provided answers that are known to be treatments for chronic pain such as
 ibuprofen. Translator also provided answers that are correct but not terribly interesting or necessarily aligned with
 user intent such as caffeine (an adjuvant included in certain pain medication). Also included among Translator answers
-to the example query are answers such as naltrexone, an opioid antagonist. In support of naltrexone, Translator
+to the example query are answers such as naltrexone, an opioid antagonist, which may not be expected by users. In support of naltrexone, Translator
 provided evidence and provenance indicating that naltrexone indeed may be used to treat chronic pain, as highlighted
-below. Translator evidence and provenance included ranked answers with scores, primary and secondary data sources
-behind any assertions, PMIDs and links to abstracts, etc. 
+below. Translator evidence and provenance included ranked answers with scores, primary and secondary knowledge sources
+behind any assertions, PubMedCentral or PubMed identifiers, and links to abstracts, etc. 
 
 This sort of serendipitous discovery, or unexpected insight, represents the type of scientific discovery that
 Translator aims to foster.

--- a/docs/architecture/kp.md
+++ b/docs/architecture/kp.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-TBA  - description of what an KP is and what it does (Chris B)
+Knowledge Providers (KPs) contribute domain-specific, high-value information abstracted from one or more underlying “knowledge sources,” which may be “raw” data or information that has been abstracted from the data
 
 ## Tutorials
 
@@ -18,5 +18,6 @@ TBA  - description of what an KP is and what it does (Chris B)
 | Clinical Data Provider  | Columbia Open Health Data ('COHD') | [WengLab-InformaticsResearch/cohd_api](https://github.com/WengLab-InformaticsResearch/cohd_api) |
 | Clinical Data Provider  | OpenPredict                        | [MaastrichtU-IDS/translator-openpredict](https://github.com/MaastrichtU-IDS/translator-openpredict) |
 | Clinical Data Provider  | Knowledge Collaboratory            | [MaastrichtU-IDS/knowledge-collaboratory-api](https://github.com/MaastrichtU-IDS/knowledge-collaboratory-api)|
-
+| Exposures Provider      | Integrated Clinical and Environmental Exposures Service (ICEES KG) | [ICEES+ and ICEES KG wiki page](https://github.com/NCATSTranslator/Translator-All/wiki/Exposures-Provider-ICEES)
+| Exposures Provider      | Causal Activity Model (CAM) KP     | [CAM KP wiki page](https://github.com/NCATSTranslator/Translator-All/wiki/Exposures-Provider-CAM-AOP)
 

--- a/docs/architecture/registry.md
+++ b/docs/architecture/registry.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The members of the Translator consortium have created many web-based Application Programming Interfaces (APIs) to share knowledgebases and tools.  Following its feasibility phase, the Biomedical Data Translator Consortium endorsed the SmartAPI Registry as the standard online registry for such APIs.  A dedicated ✨[Translator SmartAPI Registry portal](https://smart-api.info/portal/translator) now provides access to:
+Members of the Translator consortium have created many web-based Application Programming Interfaces (APIs) to share knowledgebases and tools.  Following its feasibility phase, the Translator Consortium endorsed the SmartAPI Registry as the standard online registry for such APIs.  A dedicated ✨[Translator SmartAPI Registry portal](https://smart-api.info/portal/translator) now provides access to:
 
 - The ✨[official registry of Translator APIs](https://smart-api.info/registry/translator?tags=translator).
 - [Facilities to monitor SmartAPI metadata files and API endpoints for changes and availability](#uptime-status-and-source-status-monitoring) to ensure that researcher access to reliable APIs.
@@ -15,7 +15,7 @@ The members of the Translator consortium have created many web-based Application
 
 ## About SmartAPI
 
-The SmartAPI project aims to maximize the **FAIRness** *(Findability, Accessibility, Interoperability, and Reusability)* of web-based APIs. Rich metadata is essential to properly describe an API so that it becomes discoverable, connected, and reusable. The SmartAPI metadata specification is an [OpenAPI](http://openapis.org/)-based [specification](https://github.com/SmartAPI/smartAPI-Specification/blob/OpenAPI.next/versions/3.0.0.md) that defines key API-metadata elements and value-sets. It also uses [JSON-LD](http://json-ld.org/) to provide semantically-annotated JSON content that can be treated as [Linked Data](http://linkeddata.org/). After writing a SmartAPI metadata file for an API, that file can be registered in the SmartAPI Registry to make the API discoverable and reusable for others.
+The SmartAPI project aims to maximize the **FAIRness** *(Findability, Accessibility, Interoperability, and Reusability)* of web-based APIs. Rich metadata is essential to properly describe an API so that it becomes discoverable, connected, and reusable. The SmartAPI metadata specification is an [OpenAPI](http://openapis.org/)-based [specification](https://github.com/SmartAPI/smartAPI-Specification/blob/OpenAPI.next/versions/3.0.0.md) that defines key API-metadata elements and value sets. It also uses [JSON-LD](http://json-ld.org/) to provide semantically-annotated JSON content that can be treated as [Linked Data](http://linkeddata.org/). After writing a SmartAPI metadata file for an API, that file can be registered in the SmartAPI Registry to make the API discoverable and reusable for others.
 
 **⭐ Tip:** [SmartAPI](https://smart-api.info/) provides an easy-to-use ✅ [API Metadata Editor](https://smart-api.info/editor) to quickly get started documenting your API to the latest OpenAPI v3 specification.
 
@@ -51,9 +51,9 @@ APIs in the Translator SmartAPI Registry must provide Translator-specific metada
 
 ### Registering your Translator API
 
-To make registering a new API easier, the SmartAPI Registry provides a helpful ✨[registration guide](https://smart-api.info/guide). This guide provides helpful links to examples, tools and resources to help you write SmartAPI metadata files to document your API.
+To make registering a new API easier, the SmartAPI Registry provides a helpful ✨[registration guide](https://smart-api.info/guide). This guide provides helpful links to examples, tools, and resources to help you write SmartAPI metadata files to document your API.
 
-Once the SmartAPI metadata file for your API is ready, you can head over to [SmartAPI](https://smart-api.info/) and login using your **GitHub** account.  Then head over to the [Add an API](https://smart-api.info/add-api) page to register your tool.  After successfully adding your tool, it will appear on your [user dashboard](https://smart-api.info/dashboard) where you can manage anything related to your tool.
+Once the SmartAPI metadata file for your API is ready, you can head over to [SmartAPI](https://smart-api.info/) and login using your **GitHub** account.  Then head over to the [Add an API](https://smart-api.info/add-api) page to register your tool.  After successfully adding your tool, it will appear on your [user dashboard](https://smart-api.info/dashboard), where you can manage anything related to your tool.
 
 ## Getting Help
 

--- a/docs/architecture/sri.md
+++ b/docs/architecture/sri.md
@@ -31,8 +31,7 @@ _**Revision required! First table copies [Wiki](from https://github.com/NCATSTra
 | Biolink Lookup Service | [TranslatorSRI/bl_lookup](https://github.com/TranslatorSRI/bl_lookup)                                                     |
 | Biolink Model Toolkit | [biolink/biolink-model-toolkit](https://github.com/biolink/biolink-model-toolkit)                                         |
 | Knowledge Graph Exchange Registry | [NCATSTranslator/Knowledge_Graph_Exchange_Registry](https://github.com/NCATSTranslator/Knowledge_Graph_Exchange_Registry) |
-| Knowledge Graph Exchange | [biolink/kgx](https://github.com/biolink/kgx)                                                                             |
-| Translator Mini-hackathon | [NCATSTranslator/minihackathons](https://github.com/NCATSTranslator/minihackathons)                                       |
+| Knowledge Graph Exchange | [biolink/kgx](https://github.com/biolink/kgx)                                                   |
 | Translator Name Resolution | [TranslatorSRI/NameResolution](https://github.com/TranslatorSRI/NameResolution)                                           |
 | Translator Node Normalization | [TranslatorSRI/NodeNormalization](https://github.com/TranslatorSRI/NodeNormalization)                                     |
 | SRI Plater | [TranslatorSRI/Plater](https://github.com/TranslatorSRI/Plater)                                                                               |

--- a/docs/architecture/trapi.md
+++ b/docs/architecture/trapi.md
@@ -1,8 +1,8 @@
-# Translator Reasoner Application Programming Interface (TRAPI)
+# Translator Reasoner Application Programming Interface
 
-The Translator strives to navigate, integrate, and interpret statements of biomedical knowledge ("knowledge graphs") consisting of concepts ("nodes") linked by their predicate relationships ("edges"). Such knowledge is standardized and made visible by wrappers (Knowledge Providers ("KPs")) of third-party sources, for access by computational engines (Autonomous Relay Agents ("ARAs")), thus providing value-added reasoning. 
+The Translator strives to navigate, integrate, and interpret statements of biomedical knowledge ("KGs") consisting of concepts ("nodes") linked by their predicate relationships ("edges"). Such knowledge is standardized and made visible by wrappers ("KPs") of third-party sources, for access by computational engines ("ARAs"), thus providing value-added reasoning. 
 
-Although some such components and knowledge graphs are amenable to centralized solutions, a more general solution to the task is the creation of a standardized network of commuication across distinct, distributed KPs and ARAs, with knowledge queries orchestrated within [workflows](workflows.md). In Translator, this is the goal of TRAPI.
+Although some such components and knowledge graphs are amenable to centralized solutions, a more general solution to the task is the creation of a standardized network of commuication across distinct, distributed KPs and ARAs, with knowledge queries orchestrated within [workflows](workflows.md). In Translator, this is the goal of the Translator Reasoner Application Programming Interface (TRAPI).
 
 TRAPI defines a standard HTTP web service API for communicating biomedical questions and answers. It leverages the standards of the  [Biolink model](https://biolink.github.io/biolink-model/) to precisely describe the semantics of biological entities and relationships. TRAPI's graph-based query-knowledge-binding structure enables expressive yet concise description of biomedical questions and answers.
 

--- a/docs/architecture/trapi.md
+++ b/docs/architecture/trapi.md
@@ -1,14 +1,14 @@
-# Translator Application Programming Interface (TRAPI)
+# Translator Reasoner Application Programming Interface (TRAPI)
 
-The Biomedical Data Translator ("Translator") strives to navigate, integrate and interpret statements of biomedical knowledge ("knowledge graphs") consisting of concepts ("nodes") linked by their predicate relationships ("edges"). Such knowledge is standardized and made visible by wrappers (Knowledge Providers ("KPs")) of 3rd party sources, for access by computational engines (Autonomous Relay Agents ("ARAs")) providing value added reasoning. 
+The Translator strives to navigate, integrate, and interpret statements of biomedical knowledge ("knowledge graphs") consisting of concepts ("nodes") linked by their predicate relationships ("edges"). Such knowledge is standardized and made visible by wrappers (Knowledge Providers ("KPs")) of third-party sources, for access by computational engines (Autonomous Relay Agents ("ARAs")), thus providing value-added reasoning. 
 
-Although some such components and knowledge graphs are amenable to centralized solutions, a more general solution to the task is the creation of a standardized network of commuication across distinct, distributed KPs and ARAs, with knowledge queries orchestrated within [workflows](workflows.md). In Translator, this is the goal of the Translator Reasoner API.
+Although some such components and knowledge graphs are amenable to centralized solutions, a more general solution to the task is the creation of a standardized network of commuication across distinct, distributed KPs and ARAs, with knowledge queries orchestrated within [workflows](workflows.md). In Translator, this is the goal of TRAPI.
 
-The Translator Reasoner API (TRAPI) defines a standard HTTP web service API for communicating biomedical questions and answers. It leverages the standards of the  [Biolink model](https://biolink.github.io/biolink-model/) to precisely describe the semantics of biological entities and relationships. TRAPI's graph-based query-knowledge-binding structure enables expressive yet concise description of biomedical questions and answers.
+TRAPI defines a standard HTTP web service API for communicating biomedical questions and answers. It leverages the standards of the  [Biolink model](https://biolink.github.io/biolink-model/) to precisely describe the semantics of biological entities and relationships. TRAPI's graph-based query-knowledge-binding structure enables expressive yet concise description of biomedical questions and answers.
 
 TRAPI is described primarily by an [OpenAPI](https://github.com/OAI/OpenAPI-Specification) document [here](https://github.com/NCATSTranslator/ReasonerAPI/blob/master/TranslatorReasonerAPI.yaml). The request/response structure is also documented in a more human-readable form [here](https://github.com/NCATSTranslator/ReasonerAPI/blob/master/docs/reference.md).
 
-The Translator Application Programming Interface consists of two endpoints off the main server url:
+TRAPI consists of two endpoints off the main server url:
 
 # The /meta_knowledge_graph Endpoint
 

--- a/docs/architecture/ui.md
+++ b/docs/architecture/ui.md
@@ -1,5 +1,7 @@
 # Translator User Interface
 
+The Translator User Interface (UI) is under development as a Web interface to the Translator system that receives scored results and evidence, confidence, and provenance from the ARS and exposes results to users.
+ 
  * Andy Crouse et al to elaborate.
 
 ## Tutorials

--- a/docs/architecture/workflows.md
+++ b/docs/architecture/workflows.md
@@ -1,8 +1,7 @@
-# Operations and workflows
+# Operations and Workflows
 In the current (2022) Translator architecture, TRAPI queries are akin to database lookups: a query graph is sent as input,
 and knowledge satisfying that query is sent in return. Users may wish to perform subsequent operations on these results 
-or utilize additional capabilities of Translator components besides "query lookups." The Operations and Workflow (here 
-abbreviated with **O/W**) is designed to fulfill this purpose.
+or utilize additional capabilities of Translator components besides "query lookups." Operations and Workflows (O/W) is designed to fulfill this purpose.
 
 ## What is a workflow?
 A workflow is a sequential series of specified actions (called _operations_) that instructs Translator components 
@@ -13,10 +12,10 @@ querying specific knowledge providers, etc. A list of currently implemented oper
 
 ## How is an operation structured?
 Operations are structured JSON objects that are inserted into the `Workflow` section of a TRAPI message. Operations 
-are organized into a hierarchical fashion, with most Translator components capable of executing some leaf-node operations. 
+are organized in an hierarchical fashion, with most Translator components capable of executing some leaf-node operations. 
 For example, consider the `Overlay` operation: as specified in the 
-[description](https://github.com/NCATSTranslator/OperationsAndWorkflows/blob/main/operations/overlay.yml#L3) this 
-defines an "overlay" operation as something that adds additional edges in the knowledge graph and/or query graph. The 
+[description](https://github.com/NCATSTranslator/OperationsAndWorkflows/blob/main/operations/overlay.yml#L3) that 
+defines an "overlay" operation as something that adds additional edges in the KG and/or query graph. The 
 sub-operations define what exactly is "overlaid" on the graph. An example leaf-node subclass operation is 
 `overlay_compute_ngd` and an example of calling it would be:
 ```
@@ -39,16 +38,16 @@ sub-operations define what exactly is "overlaid" on the graph. An example leaf-n
     "Id":"filter_results_top_n", "parameters":{"max_results": 10}]
 }
 ```
-So here the `overlay_compute_ngd` operation computes the 
+So here, the `overlay_compute_ngd` operation computes the 
 [Normalized Google Distance](https://en.wikipedia.org/wiki/Normalized_Google_distance) 
 between all nodes corresponding to `q_node` id `n0` and `n1` and populates this on a new edge labeled `NGD1`. 
 
 Operations have a variety of properties, including input requirements, output guarantees, allowed changes, and parameters.
 
 Importantly, operations that have the `unique: true` property are expected to result in different behavior depending on 
-which Translator component the operation is sent to. For example, the `fill` operation populates a knowledge graph with 
+which Translator component the operation is sent to. For example, the `fill` operation populates a KG with 
 bioentities that satisfy an input query graph. It is assumed that different components can fill different kinds of knowledge, 
-so this operation has the `unique: tree` property. Other operations (such as some sorting operations) have `unique: false` since each 
+so this operation has the `unique: tree` property. Other operations (such as some sorting operations) have `unique: false` because each 
 component is expected to perform the operation in the same fashion.
 
 ### Compound operations
@@ -58,21 +57,21 @@ as to sequentially executing the sub-operations that comprise it.
 
 # Using operations
 
-A TRAPI query that utilizes the O/W language may or may not have a populated query graph and/or knowledge graph. For example, 
+A TRAPI query that utilizes the O/W language may or may not have a populated query graph and/or KG. For example, 
 a `fill` operation may only have a populated query graph, while a `filter` operation may have a populated query graph 
-and knowledge graph.
+and KG.
 
 Typically, if you are starting with a "fresh" query, the usual procedure is as follows:
 
-- Provide a query graph and empty knowledge graph, and populate the `Workflow` portion of the TRAPI query with the following operations:
+- Provide a query graph and empty KG, and populate the `Workflow` portion of the TRAPI query with the following operations:
   - `fill` this will instruct Translator components to find knowledge that satisfies the query graph (akin to a database lookup)
   - Any of the `annotate`, `filter`, or `overlay` operations to argument the knowledge with additional information, filter 
 out some bioentities, etc.
   - `bind` and `complete_results` as this will form the answer set for the query
   - Additional `sort` or `filter` operations as desired.
 
-A "standard" TRAPI query (without a workflow) is equivalent to sending a query graph and calling `lookup_and_score` 
-as this will only find bioentities that satisfy a query graph, score/rank the results, and return it to a user.
+A "standard" TRAPI query (without a workflow) is equivalent to sending a query graph and calling `lookup_and_score`, 
+as this will only find bioentities that satisfy a query graph, score/rank the results, and return them to a user.
 
 More complicated workflows can be created by mixing and matching the above typical procedure. For example, 
 [here](https://gist.github.com/dkoslicki/44c3352a2b86d214e4fe104e5ab2ac47) is a workflow that:
@@ -90,7 +89,7 @@ In this fashion, a user can precisely specify what sort of workflow they desire.
 # Advertising operations
 Each Translator component is expected to implement a set of operations that it can perform. This is done via 
 the OpenAPI specification utilizing the `x-trapi` extension. Directions on how to implement this can be found
-[here](https://github.com/NCATSTranslator/OperationsAndWorkflows/wiki/How-to-%22do%22-operations#advertising-operations)
+[here](https://github.com/NCATSTranslator/OperationsAndWorkflows/wiki/How-to-%22do%22-operations#advertising-operations),
  with a real-world example [here](https://arax.ncats.io/test/api/arax/v1.2/openapi.json).
 
 # Implementing operations
@@ -103,8 +102,8 @@ specified in the `workflow` section of a TRAPI message. This is a strict require
 an operation it has not implemented, it must throw an error. No additional operations or actions are to be performed 
 besides that which is specified in the `workflow` section.
 
-Each Translator ARA is required to at minimum implement the `lookup` and/or `lookup_and_score` operations. These are 
-equivalent to a standard TRAPI query without the `workflow` section. KP's can optionally implement these operations.
+Each Translator ARA is required to, at minimum, implement the `lookup` and/or `lookup_and_score` operations. These are 
+equivalent to standard TRAPI queries without the `workflow` section. KP's can optionally implement these operations.
 
 Translator components are encouraged to create PRs to implement additional operations. This is a mechanism 
 by which components can expose additional functionality that may not currently fit in the "non-workflow" TRAPI paradigm.
@@ -113,16 +112,16 @@ by which components can expose additional functionality that may not currently f
 The workflow runner is a component that is responsible for identifying which Translator components can execute the 
 specified operations in a workflow, sending the TRAPI message to those components, and then combining and returning the results. 
 The figure below depicts the architecture of the workflow runner and how it is related to the ARS and ARAs. Note 
-that the workflow runner is a component that is not a part of the ARS or ARAs, but is instead a component that is that sits 
+that the workflow runner is a component that is not a part of the ARS or ARAs, but is instead a component that sits 
 between the ARS and ARAs/KPs. Thought it is not shown here, any KP can also advertise operations it can perform (as described 
-above) and the workflow runner will query these KPs if given a workflow with the relevant operation.
+above), and the workflow runner will query these KPs if given a workflow with the relevant operation.
 
 <img width="841" alt="Screen Shot 2022-06-24 at 3 58 12 PM" src="https://user-images.githubusercontent.com/6362936/175659052-4b0b12c3-1e03-4715-ac0e-540dd6d2144a.png">
 
-If the workflow runner is unable to find a component that can perform the operation, it will throw an error. 
+If the workflow runner is unable to find a component that can perform the operation, then it will return an error. 
 When the workflow runner is given a workflow, it will iterate through the operations in the workflow and:
-- If the operations is marked as `unique: true`, it will send the TRAPI message to all component(s) that implements that operation
-- If the operations is marked as `unique: false`, it will send the TRAPI message to a single component that implement that operation
+- If the operation(s) is marked as `unique: true`, then it will send the TRAPI message to all component(s) that implements that operation
+- If the operation(s) is marked as `unique: false`, then it will send the TRAPI message to a single component that implement that operation
 
 After each operation is executed, the results are combined before executing subsequent operations.
 


### PR DESCRIPTION
Inserted minor edits; removed abbreviation "BDTC" ("Translator" is the only NCATS-approved abbreviation); changed description of figure to acknowledge that the timeline captures program inception through September 2022. Note that another option is to remove the figure or try to keep it updated.