### PR TITLE
Editing and change Clinical Data KP links

### DIFF
--- a/docs/architecture/kp.md
+++ b/docs/architecture/kp.md
@@ -7,17 +7,17 @@ Knowledge Providers (KPs) contribute domain-specific, high-value information abs
 ## Tutorials
 
 * [Knowledge Provider tutorials](../guide-for-developers/tutorials/index.md)
-* 
-## Existing Translator KP's
 
-| Contact Team            | Name                               | Github Repository                                     |
+## Existing Translator KPs
+
+| Contact Team            | Name                               | Documentation                                         |
 |-------------------------|------------------------------------|-------------------------------------------------------|
 | Molecular Data Provider | Molecular Data Provider ('MolePro')| [broadinstitute/molecular-data-provider](https://github.com/broadinstitute/molecular-data-provider) |
 | Service Provider        | BioThings                          | [biothings/BioThings_Explorer_TRAPI](https://github.com/biothings/BioThings_Explorer_TRAPI) |
 | Text Mining Provider    | Text Mining Provider               | [NCATSTranslator/Text-Mining-Provider-Roadmap](https://github.com/NCATSTranslator/Text-Mining-Provider-Roadmap) |
-| Clinical Data Provider  | Columbia Open Health Data ('COHD') | [WengLab-InformaticsResearch/cohd_api](https://github.com/WengLab-InformaticsResearch/cohd_api) |
-| Clinical Data Provider  | OpenPredict                        | [MaastrichtU-IDS/translator-openpredict](https://github.com/MaastrichtU-IDS/translator-openpredict) |
-| Clinical Data Provider  | Knowledge Collaboratory            | [MaastrichtU-IDS/knowledge-collaboratory-api](https://github.com/MaastrichtU-IDS/knowledge-collaboratory-api)|
+| Clinical Data Provider  | Columbia Open Health Data ('COHD') | [COHD KP wiki page](https://github.com/NCATSTranslator/Translator-All/wiki/COHD-KP) |
+| Clinical Data Provider  | OpenPredict                        | [OpenPredict KP wiki page](https://github.com/NCATSTranslator/Translator-All/wiki/OpenPredict-KP) |
+| Clinical Data Provider  | Knowledge Collaboratory            | [Knowledge Collaboratory KP wiki page](https://github.com/NCATSTranslator/Translator-All/wiki/Knowledge-Collaboratory-KP)|
 | Exposures Provider      | Integrated Clinical and Environmental Exposures Service (ICEES KG) | [ICEES+ and ICEES KG wiki page](https://github.com/NCATSTranslator/Translator-All/wiki/Exposures-Provider-ICEES)
 | Exposures Provider      | Causal Activity Model (CAM) KP     | [CAM KP wiki page](https://github.com/NCATSTranslator/Translator-All/wiki/Exposures-Provider-CAM-AOP)
 


### PR DESCRIPTION
Changed Clinical Data Provider links to point to the Translator Wiki pages (following suit from Exposures Provider). Changed column heading from "Github Repo" to "Documentation" to fit the content of the column better. 

Minor edits:
* removed extra bullet under Tutorials
* "KP's" -> "KPs"