### PR TITLE
Move TRAPI under Shared Standards

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,10 +22,10 @@ nav:
         - Knowledge Providers:
           - Overview: architecture/kp.md
           - Service Provider: architecture/kp/service_provider.md
-        - Translator Reasoner API ('TRAPI'): architecture/trapi.md
         - Shared Standards and Tools:
           - Introduction: architecture/sri.md
           - Biolink Model: "https://biolink.github.io/biolink-model/"
+          - Translator Reasoner API (TRAPI): architecture/trapi.md          
           - Evidence, Provenance & Confidence Metadata: architecture/epc.md
     - Developer Guide:
         - Introduction: guide-for-developers/index.md


### PR DESCRIPTION
Currently, in the navigation panel, the formatting makes the TRAPI page look like it falls somewhat under the KP group. I suggest moving this to either the Shared Standards and Tools group (edits in this pull request) or under Architecture. 