### PR TITLE
Updated references and citations on front page

### DIFF
--- a/docs/about/index.md
+++ b/docs/about/index.md
@@ -40,8 +40,8 @@ drug-induced liver injury, and many others.
 1. Austin CP, Colvis, CM, Southall NT. **Deconstructing the Translational Tower of Babel.** _Clin Transl Sci_, 2019;12(2):85. [doi:10.1111/cts.12595](https://doi.org/10.1111/cts.12595). [PMID:30412342](https://pubmed.ncbi.nlm.nih.gov/30412342/).
 2. The Biomedical Data Translator Consortium. **Toward a Universal Biomedical Data Translator.** _Clin Transl Sci_, 2019a. [doi:10.1111/cts.12591](https://doi.org/10.1111/cts.12591). [PMID:30412337](https://pubmed.ncbi.nlm.nih.gov/30412337/).
 3. The Biomedical Data Translator Consortium. **The Biomedical Data Translator program: conception, culture, and community.** _Clin Transl Sci_, 2019b. [doi:10.1111/cts.12592](https://doi.org/10.1111/cts.12592). [PMID:30412340](https://pubmed.ncbi.nlm.nih.gov/30412340/).
-4. Fecho K, Thessen AE, Baranzini SE, et al. and The Biomedical Data Translator Consortium. **Progress toward a Universal Biomedical Data Translator.** _Clin Transl Sci_, 2022 May 25. [doi:10.1111/cts.13301](https://ascpt.onlinelibrary.wiley.com/doi/full/10.1111/cts.13301). [PMID:35611543](https://pubmed.ncbi.nlm.nih.gov/35611543/).
-5. Unni DR, Moxon SAT, Bada M, et al. and the Biomedical Data Translator Consortium. **Biolink Model: a universal schema for knowledge graphs in clinical, biomedical, and translational science.** _Clin Transl Sci_, 2022 June 6. [doi:10.1111/cts.13302](https://ascpt.onlinelibrary.wiley.com/doi/full/10.1111/cts.13302).
+4. Fecho K, Thessen AE, Baranzini SE, et al. and The Biomedical Data Translator Consortium. **Progress toward a Universal Biomedical Data Translator.** _Clin Transl Sci_, 2022 May 25. [doi:10.1111/cts.13301](https://doi.org/10.1111/cts.13301). [PMID:35611543](https://pubmed.ncbi.nlm.nih.gov/35611543/).
+5. Unni DR, Moxon SAT, Bada M, et al. and the Biomedical Data Translator Consortium. **Biolink Model: a universal schema for knowledge graphs in clinical, biomedical, and translational science.** _Clin Transl Sci_, 2022 June 6. [doi:10.1111/cts.13302](https://doi.org/10.1111/cts.13302).
 
 ##  Licensing
 

--- a/docs/about/index.md
+++ b/docs/about/index.md
@@ -37,9 +37,9 @@ drug-induced liver injury, and many others.
 
 ## References
 
-1. Austin CP, Colvis, CM, Southall NT. **Deconstructing the Translational Tower of Babel.** _Clin Transl Sci_, 2019;12(2):85. [doi:10.1111/cts.12595](https://ascpt.onlinelibrary.wiley.com/doi/10.1111/cts.12595). [PMID:30412342](https://pubmed.ncbi.nlm.nih.gov/30412342/).
-2. The Biomedical Data Translator Consortium. **Toward a Universal Biomedical Data Translator.** _Clin Transl Sci_, 2019a;12(2):91–94. [doi:10.1111/cts.12592](https://ascpt.onlinelibrary.wiley.com/doi/full/10.1111/cts.12592). [PMID:30412337](https://pubmed.ncbi.nlm.nih.gov/30412337/).
-3. The Biomedical Data Translator Consortium. **The Biomedical Data Translator program: conception, culture, and community.** _Clin Transl Sci_, 2019b;12(2):86–90. doi: 10.1111/cts.13021. [PMID:30412340](https://pubmed.ncbi.nlm.nih.gov/30412340/).
+1. Austin CP, Colvis, CM, Southall NT. **Deconstructing the Translational Tower of Babel.** _Clin Transl Sci_, 2019;12(2):85. [doi:10.1111/cts.12595](https://doi.org/10.1111/cts.12595). [PMID:30412342](https://pubmed.ncbi.nlm.nih.gov/30412342/).
+2. The Biomedical Data Translator Consortium. **Toward a Universal Biomedical Data Translator.** _Clin Transl Sci_, 2019a. [doi:10.1111/cts.12591](https://doi.org/10.1111/cts.12591). [PMID:30412337](https://pubmed.ncbi.nlm.nih.gov/30412337/).
+3. The Biomedical Data Translator Consortium. **The Biomedical Data Translator program: conception, culture, and community.** _Clin Transl Sci_, 2019b. [doi:10.1111/cts.12592](https://doi.org/10.1111/cts.12592). [PMID:30412340](https://pubmed.ncbi.nlm.nih.gov/30412340/).
 4. Fecho K, Thessen AE, Baranzini SE, et al. and The Biomedical Data Translator Consortium. **Progress toward a Universal Biomedical Data Translator.** _Clin Transl Sci_, 2022 May 25. [doi:10.1111/cts.13301](https://ascpt.onlinelibrary.wiley.com/doi/full/10.1111/cts.13301). [PMID:35611543](https://pubmed.ncbi.nlm.nih.gov/35611543/).
 5. Unni DR, Moxon SAT, Bada M, et al. and the Biomedical Data Translator Consortium. **Biolink Model: a universal schema for knowledge graphs in clinical, biomedical, and translational science.** _Clin Transl Sci_, 2022 June 6. [doi:10.1111/cts.13302](https://ascpt.onlinelibrary.wiley.com/doi/full/10.1111/cts.13302).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 # Welcome to Developer Documentation for the Biomedical Data Translator
 
-The [**Biomedical Data Translator** ('Translator')](https://ncats.nih.gov/translator)  program was launched by the
+The [**Biomedical Data Translator** ("Translator")](https://ncats.nih.gov/translator)  program was launched by the
 [National Center for Advancing Translational Sciences ("NCATS")](https://ncats.nih.gov) in Fall of 2016. 
 
 The vision of the Translator program is to accelerate translational science “through an informatics platform that 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,9 +5,11 @@
 The [**Biomedical Data Translator** ("Translator")](https://ncats.nih.gov/translator)  program was launched by the
 [National Center for Advancing Translational Sciences ("NCATS")](https://ncats.nih.gov) in Fall of 2016. 
 
-The vision of the Translator program is to accelerate translational science “through an informatics platform that 
-enables interrogation of relationships across the full spectrum of data types” ([Austin et al. 2019; BDTC 2019a/b;
-Fecho _et al._ 2022](about/index.md#references)). The goal is to build the infrastructure required to support and 
+The vision of the Translator program is to accelerate translational science "through an informatics platform that 
+enables interrogation of relationships across the full spectrum of data types"
+([Austin et al. 2019](https://doi.org/10.1111/cts.12595), [BDTC 2019a](https://doi.org/10.1111/cts.12592),
+[BDTC 2019b](https://doi.org/10.1111/cts.12592), [Fecho _et al._ 2022](https://doi.org/10.1111/cts.13301),
+[other references](about/index.md#references)). The goal is to build the infrastructure required to support and 
 facilitate data-driven translational research on a large scale. The fundamental aim is to integrate as many datasets
 as possible, using a ‘knowledge graph’–based architecture, and allow them to be cross-queried and reasoned over by
 translational researchers. A fundamental tenet of the Translator program is open data, including open (de-identified) 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ The [**Biomedical Data Translator** ("Translator")](https://ncats.nih.gov/transl
 [National Center for Advancing Translational Sciences ("NCATS")](https://ncats.nih.gov) in Fall of 2016. 
 
 The vision of the Translator program is to accelerate translational science “through an informatics platform that 
-enables interrogation of relationships across the full spectrum of data types” ([Austin et al. 2019; BDTC 2919a/b;
+enables interrogation of relationships across the full spectrum of data types” ([Austin et al. 2019; BDTC 2019a/b;
 Fecho _et al._ 2022](about/index.md#references)). The goal is to build the infrastructure required to support and 
 facilitate data-driven translational research on a large scale. The fundamental aim is to integrate as many datasets
 as possible, using a ‘knowledge graph’–based architecture, and allow them to be cross-queried and reasoned over by

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ The [**Biomedical Data Translator** ("Translator")](https://ncats.nih.gov/transl
 
 The vision of the Translator program is to accelerate translational science "through an informatics platform that 
 enables interrogation of relationships across the full spectrum of data types"
-([Austin et al. 2019](https://doi.org/10.1111/cts.12595), [BDTC 2019a](https://doi.org/10.1111/cts.12591),
+([Austin _et al._ 2019](https://doi.org/10.1111/cts.12595), [BDTC 2019a](https://doi.org/10.1111/cts.12591),
 [BDTC 2019b](https://doi.org/10.1111/cts.12592), [Fecho _et al._ 2022](https://doi.org/10.1111/cts.13301),
 [other references](about/index.md#references)). The goal is to build the infrastructure required to support and 
 facilitate data-driven translational research on a large scale. The fundamental aim is to integrate as many datasets

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ The [**Biomedical Data Translator** ("Translator")](https://ncats.nih.gov/transl
 
 The vision of the Translator program is to accelerate translational science "through an informatics platform that 
 enables interrogation of relationships across the full spectrum of data types"
-([Austin et al. 2019](https://doi.org/10.1111/cts.12595), [BDTC 2019a](https://doi.org/10.1111/cts.12592),
+([Austin et al. 2019](https://doi.org/10.1111/cts.12595), [BDTC 2019a](https://doi.org/10.1111/cts.12591),
 [BDTC 2019b](https://doi.org/10.1111/cts.12592), [Fecho _et al._ 2022](https://doi.org/10.1111/cts.13301),
 [other references](about/index.md#references)). The goal is to build the infrastructure required to support and 
 facilitate data-driven translational research on a large scale. The fundamental aim is to integrate as many datasets


### PR DESCRIPTION
I've proposed four sets of changes here:
1. I've replaced direct links to publications with DOI links instead (i.e. https://doi.org/...). This should make it easier for machines to make sense of these links (without going all the way to using [COinS](https://en.wikipedia.org/wiki/COinS)), and gives us a bit of future proofing in case the direct link changes in the future.
2. I've changes the link to the references section on the front page with three links to each separate publication.
3. I fixed the link to BDTC 2019b.
4. The text read `Biomedical Data Translator** ('Translator') ... National Center for Advancing Translational Sciences ("NCATS")` -- I've replaced that with `"Translator"` so as to standardize them.