### PR TITLE
Update style to material for mkdocs

### DIFF
--- a/docs/includes/abbreviations.md
+++ b/docs/includes/abbreviations.md
@@ -1,0 +1,48 @@
+*[NIH]: National Institutes of Health
+*[NCATS]: National Center for Advancing Translational Sciences
+*[KP]: Knowledge Provider
+*[KPs]: Knowledge Providers
+*[ARA]: Autonomous Relay Agent
+*[ARAs]: Autonomous Relay Agents
+*[ARS]: Autonomous Relay System
+*[ARAX]: Expander Agent
+*[SRI]: Standards and Reference Implementation
+*[TRAPI]: Translator Reasoner API
+*[COHD]: Columbia Open Health Data
+*[EPC]: Evidence, Provenance and Confidence
+*[TCDC]: Translator Clinical Data Committee
+*[ITRB]: Information Technology Resources Branch
+*[API]: Application Programming Interface
+*[KG]: Knowledge Graph
+*[HTML]: Hyper Text Markup Language
+*[LLM]: Large Language Model
+*[LLMs]: Large Language Models
+*[ML]: Machine Learning
+*[DL]: Deep Learning
+*[QA]: Question Answering
+*[API]: Application Programming Interface
+*[UI]: User Interface
+*[CLI]: Command-Line Interface
+*[PyPI]: Python Packaging Index
+*[PyPA]: Python Packaging Authority
+*[PEP]: Python Enhancement Proposal
+*[YAML]: Depending on whom you ask, YAML stands for "Yet Another Markup Language", or "YAML Ain't Markup Language"
+*[JSON]: JavaScript Object Notation
+*[URL]: Uniform Resource Locator
+*[URI]: Uniform Resource Identifier
+*[IRI]: International Resource Identifier
+*[GPU]: Graphics Processing Unit
+*[CPU]: Central Processing Unit
+*[TPU]: Tensor Processing Unit
+*[RDF]: Resource Description Framework
+*[PDF]: Portable Document Format
+*[ZSH]: The Z shell (Zsh) is a Unix shell that can be used as an interactive login shell, and as a command interpreter for shell scripting.
+*[BASH]: The Bourne-Again SHell (BASH) is a Unix shell that can be used as an interactive login shell, and as a command interpreter for shell scripting.
+*[OpenAPI]: OpenAPI, formerly known as Swagger, is a specification language for HTTP APIs that defines structure and syntax in a way that is not wedded to the programming language the API is created in.
+*[JS]: JavaScript
+*[TS]: TypeScript
+*[CSS]: Cascading Style Sheets
+*[CSV]: Comma-Separated Value
+*[TSV]: Tab-Separated Value
+*[PSV]: Pipe-Separated Value
+*[ODT]: Open Document Format

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,6 +96,17 @@ markdown_extensions:
 plugins:
     - search
     - autorefs
+    - glightbox:
+        touchNavigation: true
+        loop: false
+        effect: zoom
+        slide_effect: slide
+        width: 100%
+        height: auto
+        zoomable: true
+        draggable: true
+        auto_caption: false
+        caption_position: bottom
 
 extra:
     social:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,13 +3,11 @@ site_url: https://ncatstranslator.github.io/translator-developer-documentation/
 repo_url: https://github.com/NCATSTranslator/translator-developer-documentation
 
 nav:
-    - Home:
-        - Welcome: index.md
     - About:
-        - About Translator: about/index.md
+        - About: index.md
+        - The Translator program: about/index.md
         - License: about/license.md
-    - Frequently Asked Questions:
-          - faq.md
+        - Frequently Asked Questions: faq.md
     - Architecture:
         - Introduction: architecture/index.md
         - Knowledge Graph Principles: architecture/biolink/core_knowledge_graph_principles.md
@@ -20,15 +18,15 @@ nav:
         - Autonomous Relay Agents: architecture/ara/index.md
         - Knowledge Providers: architecture/kp/index.md
         - Shared Standards and Tools:
-          - Introduction: architecture/sri.md
-          - Biolink Model: "https://biolink.github.io/biolink-model/"
-          - Translator Reasoner API (TRAPI): architecture/trapi.md          
-          - Evidence, Provenance & Confidence Metadata: architecture/epc.md
+            - Introduction: architecture/sri.md
+            - Biolink Model: "https://biolink.github.io/biolink-model/"
+            - Translator Reasoner API (TRAPI): architecture/trapi.md
+            - Evidence, Provenance & Confidence Metadata: architecture/epc.md
     - Developer Guide:
         - Introduction: guide-for-developers/index.md
         - Quick Start:
-           - Overview: guide-for-developers/quickstart.md
-           - "Hello Translator Jupyter Notebook": 'https://github.com/NCATSTranslator/translator-developer-documentation/blob/master/docs/guide-for-developers/HelloTranslator.ipynb'
+            - Overview: guide-for-developers/quickstart.md
+            - "Hello Translator Jupyter Notebook": 'https://github.com/NCATSTranslator/translator-developer-documentation/blob/master/docs/guide-for-developers/HelloTranslator.ipynb'
         - Cookbook: guide-for-developers/cookbook.md
         - Tutorials:
             - Overview: guide-for-developers/tutorials/index.md
@@ -39,10 +37,70 @@ nav:
         - Expander Agent: teams/expander-agent.md
 
 theme:
-  name: readthedocs
-  features:
-    - navigation.indexes
-    - navigation.footer
+    name: "material"
+    favicon: img/favicon.ico
+    logo: img/favicon.ico
+    icon:
+        admonition:
+        server: material/server
+    language: en
+    # Pick color: https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/#primary-color
+    palette:
+        - media: "(prefers-color-scheme: light)"
+          scheme: default
+          primary: deep purple
+          toggle:
+              icon: material/weather-night
+              name: Switch to dark mode
+        - media: "(prefers-color-scheme: dark)"
+          scheme: slate
+          primary: deep purple
+          toggle:
+              icon: material/weather-sunny
+              name: Switch to light mode
+    features:
+        - navigation.indexes
+        - navigation.footer
+        - navigation.sections
+        - navigation.tabs
+        - content.code.copy
+        - content.code.annotate
+        - content.code.select
+        - navigation.top
+        - navigation.tracking
+        - search.highlight
+        - search.share
+        - search.suggest
+        - toc.follow
 
 copyright: Copyright &copy; 2017-2023 Biomedical Data Translator<br>National Center for Advancing Translational Science
 
+markdown_extensions:
+    - admonition # Supported types: https://squidfunk.github.io/mkdocs-material/reference/admonitions/#supported-types
+    - pymdownx.highlight:
+        anchor_linenums: true
+    - pymdownx.inlinehilite
+    - pymdownx.snippets
+    - pymdownx.superfences
+    - pymdownx.tabbed:
+        alternate_style: true
+    - pymdownx.details
+    - pymdownx.extra
+    - abbr
+    - pymdownx.snippets:
+        auto_append:
+            - docs/includes/abbreviations.md
+    - attr_list
+    - smarty
+
+plugins:
+    - search
+    - autorefs
+
+extra:
+    social:
+        - icon: fontawesome/brands/github
+          link: https://github.com/NCATSTranslator
+
+watch:
+    - docs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
-mkdocs
 jinja2<3.1.0
 markdown<3.4
+mkdocs >=1.4.2
+mkdocs-material >=8.2.7
+mdx-include >=1.4.1
+mkdocs-markdownextradata-plugin >=0.2.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 jinja2<3.1.0
 markdown<3.4
+mdx-include >=1.4.1
 mkdocs >=1.4.2
 mkdocs-material >=8.2.7
-mdx-include >=1.4.1
+mkdocs-autorefs
 mkdocs-markdownextradata-plugin >=0.2.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ mkdocs >=1.4.2
 mkdocs-material >=8.2.7
 mkdocs-autorefs
 mkdocs-markdownextradata-plugin >=0.2.5
+mkdocs-glightbox


### PR DESCRIPTION
This PR brings changes to the style of the documentation website, cf. issue https://github.com/NCATSTranslator/translator-developer-documentation/issues/46 for more details about the arguments behind the changes

You can see the website with the new style available directly here: https://vemonet.github.io/translator-developer-documentation 

No changes have been made the content itself 

@RichardBruskiewich 